### PR TITLE
Add cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ requests == 2.14.0
 
 # `PyGithub` is used for interacting with GitHub's API
 PyGithub == 1.47
+
+# `cryptography` is used for interacting with Github's API with a private key
+cryptography == 2.9


### PR DESCRIPTION
This PR adds `cryptography` as a requirement.

I didn't have `cryptography` installed locally, so I thought I'd add it since the project raised an error for me. 