### PR TITLE
Add workflow for checking yapf formatting

### DIFF
--- a/.github/workflows/yapf_check.yml
+++ b/.github/workflows/yapf_check.yml
@@ -1,0 +1,16 @@
+name: YAPF Formatting Check
+
+on: [push]
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: run YAPF to test if python code is correctly formatted
+      uses: AlexanderMelde/yapf-action@master
+      with:
+        args: --verbose


### PR DESCRIPTION
Using the [YAPF Python Code Formatting Check](https://github.com/marketplace/actions/yapf-python-code-formatting-check).

> A GitHub action that runs YAPF to test if your python code is correctly formatted.
> 
> The action uses the `--diff` parameter of YAPF to return
> 
>   - SUCCESS: exit-code=zero → no changes were necessary, code is YAPF-formatted
>   - FAIL: exit-code=non-zero → not correctly formatted or program error

Proposing a workflow to check if commits have been run thru yapf. What do you think, @rye?